### PR TITLE
fix numpy version

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -17,7 +17,7 @@ matplotlib==3.5.1
 mkl-fft==1.3.1
 mkl-random==1.2.2
 mkl-service==2.4.0
-numpy==1.21.2
+numpy==1.21.4
 opencv-python==4.5.5.62
 opt-einsum==3.3.0
 packaging==21.3


### PR DESCRIPTION
Fix the error when run `pip install -r requirement.txt`
<img width="733" alt="image" src="https://user-images.githubusercontent.com/16014917/192866737-251f1248-3be9-4de6-94fd-e4fd59281bf1.png">
